### PR TITLE
Move validateAll to context 

### DIFF
--- a/src/UseInputValidator.tsx
+++ b/src/UseInputValidator.tsx
@@ -129,15 +129,6 @@ export function useInputValidator<T>(
     return errors;
   }, [validateFieldImpl, values]);
 
-  const validateAll = async () => {
-    let errors = [] as ValidationError[];
-    for (const ref of validatorRefs) {
-      const validate = ref.current?.validate;
-      validate && (errors = [...errors, ...(await validate())]);
-    }
-    return errors;
-  };
-
   const getClassName = (name: TKey, passThroughClassNames: string = "") => {
     return propertyHasErrors(name)
       ? `${passThroughClassNames} ${context.options?.classNameErrorInput || ""}`
@@ -287,7 +278,7 @@ export function useInputValidator<T>(
     resetField,
     resetLocalFields,
     context,
-    validateAll,
+    validateAll: context.validateAll,
     propertyHasErrors,
   };
 }

--- a/src/ValidationProvider.tsx
+++ b/src/ValidationProvider.tsx
@@ -20,6 +20,7 @@ export interface ValidationContextState {
   validatorRefs: MutableRefObject<ValidatorRef>[];
   options: ValidatorOptions;
   updateFormErrorCount: () => void;
+  validateAll: () => Promise<ValidationError[]>;
 }
 
 export interface ValidatorRef {
@@ -64,6 +65,15 @@ export const useOrCreateValidationContext = (
     [setFormErrorCount, isMounted]
   );
 
+  const validateAll = async () => {
+    let errors = [] as ValidationError[];
+    for (const ref of validatorRefsRef.current) {
+      const validate = ref.current?.validate;
+      validate && (errors = [...errors, ...(await validate())]);
+    }
+    return errors;
+  };
+
   if (context) {
     if (options) {
       validateOptions(options);
@@ -85,6 +95,7 @@ export const useOrCreateValidationContext = (
     validatorRefs: validatorRefsRef.current,
     options: options || {},
     updateFormErrorCount,
+    validateAll,
   };
 
   return newContext;

--- a/src/demo/components/Form.stories.tsx
+++ b/src/demo/components/Form.stories.tsx
@@ -1,11 +1,15 @@
 import React from "react";
-import { Form } from "./Form";
+import { FormProvidedWithContext, FormProvidedWithNoContext } from "./Form";
 import { formData } from "../data";
 
 export default {
   title: "TestForm",
 };
 
-export const Primary = () => <Form data={formData} />;
+export const WithExistingContext = () => (
+  <FormProvidedWithContext data={formData} />
+);
 
-export const Secondary = () => <Form data={formData} />;
+export const WithNoContext = () => (
+  <FormProvidedWithNoContext data={formData} />
+);

--- a/src/demo/components/Form.tsx
+++ b/src/demo/components/Form.tsx
@@ -1,7 +1,11 @@
 import React, { useState } from "react";
 import { Data } from "../types";
 import { dataSchema } from "../schemas";
-import { useInputValidator, ValidationProvider } from "../..";
+import {
+  useInputValidator,
+  useOrCreateValidationContext,
+  ValidationProvider,
+} from "../..";
 import { NestedForm } from "./NestedForm";
 
 export interface Props {
@@ -31,55 +35,74 @@ export const Form = (props: Props) => {
 
   return (
     <>
-      <ValidationProvider context={context}>
-        <input
-          className={getClassName("aValue")}
-          name="aValue"
-          value={data.aValue}
-          onChange={onChange("aValue", (e) =>
-            setData((d) => ({ ...d, aValue: e.target.value }))
-          )}
-          onBlur={onBlur("aValue")}
-        />
-        <InputErrorMessage name="aValue" />
-        {data.nestedValues.map((n, i) => (
-          <div key={`${i}_${n.id}`}>
-            <NestedForm
-              nestedData={n}
-              setNestedData={(nestedData) => {
-                const nestedValues = [...data.nestedValues];
-                nestedValues.splice(i, 1, nestedData);
-                setData({ ...data, nestedValues });
-              }}
-              onDelete={() => {
-                const nestedValues = [...data.nestedValues];
-                nestedValues.splice(i, 1);
-                setData({ ...data, nestedValues });
-              }}
-            />
-          </div>
-        ))}
-        <button onClick={validateAll}>Validate All</button>
-        <button
-          disabled={formErrorCount > 0}
-          onClick={async () => {
-            const errors = await validateAll();
-            if (errors.length > 0) {
-              alert("Fix errors first");
-            } else {
-              alert("Success!");
-            }
-          }}
-        >
-          Submit
-        </button>
-        <button
-          disabled={!formIsDirty && !formIsTouched && formErrorCount === 0}
-          onClick={resetContext}
-        >
-          Reset
-        </button>
-      </ValidationProvider>
+      <input
+        className={getClassName("aValue")}
+        name="aValue"
+        value={data.aValue}
+        onChange={onChange("aValue", (e) =>
+          setData((d) => ({ ...d, aValue: e.target.value }))
+        )}
+        onBlur={onBlur("aValue")}
+      />
+      <InputErrorMessage name="aValue" />
+      {data.nestedValues.map((n, i) => (
+        <div key={`${i}_${n.id}`}>
+          <NestedForm
+            nestedData={n}
+            setNestedData={(nestedData) => {
+              const nestedValues = [...data.nestedValues];
+              nestedValues.splice(i, 1, nestedData);
+              setData({ ...data, nestedValues });
+            }}
+            onDelete={() => {
+              const nestedValues = [...data.nestedValues];
+              nestedValues.splice(i, 1);
+              setData({ ...data, nestedValues });
+            }}
+          />
+        </div>
+      ))}
+      <button onClick={validateAll}>Validate All</button>
+      <button
+        disabled={formErrorCount > 0}
+        onClick={async () => {
+          const errors = await validateAll();
+          if (errors.length > 0) {
+            alert("Fix errors first");
+          } else {
+            alert("Success!");
+          }
+        }}
+      >
+        Submit
+      </button>
+      <button
+        disabled={!formIsDirty && !formIsTouched && formErrorCount === 0}
+        onClick={resetContext}
+      >
+        Reset
+      </button>
     </>
+  );
+};
+
+export const FormProvidedWithContext = (props: Props) => {
+  const context = useOrCreateValidationContext({
+    classNameErrorInput: "is-invalid",
+    classNameErrorMessage: "text-danger",
+  });
+
+  return (
+    <ValidationProvider context={context}>
+      <Form data={props.data} />
+    </ValidationProvider>
+  );
+};
+
+export const FormProvidedWithNoContext = (props: Props) => {
+  return (
+    <ValidationProvider>
+      <Form data={props.data} />
+    </ValidationProvider>
   );
 };


### PR DESCRIPTION
This will allow `validateAll()` to be used when a component only uses `useOrCreateValidationContext()`

It's needed to address ucdavis/Harvest#648